### PR TITLE
Also infer missing type when used as function return type

### DIFF
--- a/Parser/VParseLex.l
+++ b/Parser/VParseLex.l
@@ -876,6 +876,10 @@ int VParseLex::lexToken(VParseBisonYYSType* yylvalp) {
 		LPARSEP->symPopScope(VAstType::PACKAGE);
 		token = yaID__aPACKAGE;
 	    }
+	    else if (m_aheadToken[0] == yaID__LEX && m_aheadToken[1] == '('
+		     && (prevtok == yFUNCTION__LEX || prevtok == yAUTOMATIC)) {
+		token = yaID__aTYPE;
+	    }
 	    else if ((m_aheadToken[0] == yaID__LEX && m_aheadToken[1] != '(') || m_aheadToken[0] == '[') {
 		if (prevtok == '('
 		    || prevtok == ','


### PR DESCRIPTION
This PR enhances the missing type inference allowance in the Verilog parser (used primarily for dependency generation) to apply to lexer tokens that appear in `function` declarations as the return type.