### PR TITLE
Also infer missing type when used as local variable declaration

### DIFF
--- a/Parser/VParseLex.l
+++ b/Parser/VParseLex.l
@@ -880,6 +880,10 @@ int VParseLex::lexToken(VParseBisonYYSType* yylvalp) {
 		     && (prevtok == yFUNCTION__LEX || prevtok == yAUTOMATIC)) {
 		token = yaID__aTYPE;
 	    }
+	    else if (m_aheadToken[0] == yaID__LEX && (m_aheadToken[1] == ',' || m_aheadToken[1] == ';')
+		     && prevtok == yaID__LEX) {
+		token = yaID__aTYPE;
+	    }
 	    else if ((m_aheadToken[0] == yaID__LEX && m_aheadToken[1] != '(') || m_aheadToken[0] == '[') {
 		if (prevtok == '('
 		    || prevtok == ','


### PR DESCRIPTION
This PR enhances the missing type inference allowance in the Verilog parser (used primarily for dependency generation) to apply to lexer tokens that appear in local variable declarations.