### PR TITLE
Also infer missing type when used as scoped function return type

### DIFF
--- a/Parser/VParseLex.l
+++ b/Parser/VParseLex.l
@@ -879,7 +879,7 @@ int VParseLex::lexToken(VParseBisonYYSType* yylvalp) {
 		token = yaID__aPACKAGE;
 	    }
 	    else if (m_aheadToken[0] == yaID__LEX && m_aheadToken[1] == '('
-		     && (prevtok == yFUNCTION__LEX || prevtok == yAUTOMATIC)) {
+		     && (prevtok == yFUNCTION__LEX || prevtok == yAUTOMATIC || prevtok == yP_COLONCOLON)) {
 		token = yaID__aTYPE;
 	    }
 	    else if (m_aheadToken[0] == yaID__LEX && (m_aheadToken[1] == ',' || m_aheadToken[1] == ';')


### PR DESCRIPTION
This PR is a follow-on to #4's missing type inference enhancement in the Verilog parser and now also handles the scenario where a missing type is used in scope-qualified (`::`) fashion as the function return type.